### PR TITLE
ipq806x: Fix default MAC addresses on MR52 by moving to `nvmem-layout`.

### DIFF
--- a/.github/workflows/build_meraki.yml
+++ b/.github/workflows/build_meraki.yml
@@ -34,7 +34,7 @@ jobs:
                   sudo apt-get clean
             - name: Checkout
               uses: actions/checkout@v4
-	      with:
+              with:
                 ref: ${{ github.event.ref }}
 
             - name: Update feeds

--- a/.github/workflows/build_meraki.yml
+++ b/.github/workflows/build_meraki.yml
@@ -54,5 +54,6 @@ jobs:
               with:
                 tag: meraki-${{ env.SHA }}
                 commit: ${{ github.event.ref }}
+                allowUpdates: true
                 artifacts: bin/targets/ipq806x/generic/openwrt-ipq806x-generic-meraki_*
 

--- a/.github/workflows/build_meraki.yml
+++ b/.github/workflows/build_meraki.yml
@@ -53,5 +53,6 @@ jobs:
               uses: ncipollo/release-action@v1
               with:
                 tag: meraki-${{ env.SHA }}
+                commit: ${{ github.event.ref }}
                 artifacts: bin/targets/ipq806x/generic/openwrt-ipq806x-generic-meraki_*
 

--- a/.github/workflows/build_meraki.yml
+++ b/.github/workflows/build_meraki.yml
@@ -1,0 +1,55 @@
+name: Build Meraki Images
+
+on: workflow_dispatch
+
+jobs:
+    build:
+        name: Build Meraki Images
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+        steps:
+            - name: Install packages
+              run: |
+                  sudo apt-get update && \
+                  sudo apt-get install -y \
+                      build-essential \
+                      clang \
+                      flex \
+                      bison \
+                      g++ \
+                      gawk \
+                      gcc-multilib \
+                      g++-multilib \
+                      gettext \
+                      git \
+                      libncurses-dev \
+                      libssl-dev \
+                      python3-distutils \
+                      rsync \
+                      unzip \
+                      zlib1g-dev \
+                      file \
+                      wget && \
+                  sudo apt-get clean
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Update feeds
+              run:  scripts/feeds update -a && scripts/feeds install -a
+
+            - name: Generate config
+              run:  sh genconfig.sh
+
+            - name: Build firmware images
+              run: make -j$(($(nproc)+1)) world
+
+            - name: Get SHA
+              uses: benjlevesque/short-sha@v2.2
+
+            - name: Release
+              uses: ncipollo/release-action@v1
+              with:
+                tag: meraki-${{ env.SHA }}
+                artifacts: bin/targets/ipq806x/generic/openwrt-ipq806x-generic-meraki_*
+

--- a/.github/workflows/build_meraki.yml
+++ b/.github/workflows/build_meraki.yml
@@ -34,6 +34,8 @@ jobs:
                   sudo apt-get clean
             - name: Checkout
               uses: actions/checkout@v4
+	      with:
+                ref: ${{ github.event.ref }}
 
             - name: Update feeds
               run:  scripts/feeds update -a && scripts/feeds install -a

--- a/genconfig.sh
+++ b/genconfig.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+wget https://downloads.openwrt.org/snapshots/targets/ipq806x/generic/config.buildinfo -O config.buildinfo
+cat config.buildinfo | grep -v CONFIG_TARGET_DEVICE_ | grep -v CONFIG_TARGET_ALL_PROFILES | grep -v CONFIG_TARGET_MULTI_PROFILE > .config
+echo CONFIG_TARGET_ALL_PROFILES=n >> .config
+echo CONFIG_TARGET_MULTI_PROFILE=n >> .config
+echo CONFIG_TARGET_DEVICE_ipq806x_generic_DEVICE_meraki_mr42=y >> .config
+echo CONFIG_TARGET_DEVICE_ipq806x_generic_DEVICE_meraki_mr52=y >> .config
+echo CONFIG_TARGET_DEVICE_PACKAGES_ipq806x_generic_DEVICE_meraki_mr42=\"\" >> .config
+echo CONFIG_TARGET_DEVICE_PACKAGES_ipq806x_generic_DEVICE_meraki_mr52=\"\" >> .config
+
+#add luci
+echo CONFIG_PACKAGE_luci=y >> .config
+make defconfig
+
+#skip xdp
+cat .config | grep -v "CONFIG_PACKAGE.*xdp" > .config.tmp
+cp .config.tmp .config
+
+

--- a/target/linux/ipq806x/files-5.15/arch/arm/boot/dts/qcom-ipq8068-mr52.dts
+++ b/target/linux/ipq806x/files-5.15/arch/arm/boot/dts/qcom-ipq8068-mr52.dts
@@ -80,7 +80,7 @@
 	phy-mode = "sgmii";
 	phy-handle = <&phy0>;
 
-	nvmem-cells = <&mac_address>;
+	nvmem-cells = <&mac_address 0>;
 	nvmem-cell-names = "mac-address";
 };
 
@@ -93,9 +93,8 @@
 	phy-mode = "sgmii";
 	phy-handle = <&phy4>;
 
-	nvmem-cells = <&mac_address>;
+	nvmem-cells = <&mac_address 1>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <1>;
 };
 
 &gsbi7 {
@@ -142,11 +141,17 @@
 		pagesize = <32>;
 		reg = <0x52>;
 		read-only;
-		#address-cells = <1>;
-		#size-cells = <1>;
 
-		mac_address: mac-address@66 {
-			reg = <0x66 0x6>;
+		nvmem-layout {
+			compatible = "fixed-layout";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			mac_address: mac-address@66 {
+				compatible = "mac-base";
+				reg = <0x66 0x6>;
+				#nvmem-cell-cells = <1>;
+			};
 		};
 	};
 };
@@ -212,21 +217,18 @@
 };
 
 &wifi0 {
-	nvmem-cells = <&mac_address>;
+	nvmem-cells = <&mac_address 4>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <4>;
 };
 
 &wifi1 {
-	nvmem-cells = <&mac_address>;
+	nvmem-cells = <&mac_address 3>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <3>;
 };
 
 &wifi2 {
-	nvmem-cells = <&mac_address>;
+	nvmem-cells = <&mac_address 2>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <2>;
 };
 
 &hs_phy_0 {


### PR DESCRIPTION
Partial, single-target update extracted from https://github.com/rkb-org/openwrt/commit/d264d3a60ecc1813a3a10497ad3171605b9faa71

The previous `mac-address-increment` is deprecated, and in particular on
this platform means that the kernel is unable to read the MAC address,
causing the system to boot with a new random MAC address each time.

Fixes: https://github.com/openwrt/openwrt/issues/15238

Signed-off-by: Rosen Penev <rosenp@gmail.com>
[rafal.boni@gmail.com: single-target-specific backport from larger change]
Signed-off-by: Rafal Boni <rafal.boni@gmail.com>